### PR TITLE
Feat: 최고 기록 갱신 모드 추가

### DIFF
--- a/2048_game.c
+++ b/2048_game.c
@@ -321,6 +321,28 @@ void record(char key, const struct game *game)
 	}
 }
 
+int high_score = 0; //최고 기록을 저장하는 전역 변수
+
+void load_high_score()
+{
+	FILE *high_score_file = fopen("high_score.txt", "r"); //high_score.txt 파일을 읽기 모드로 열기
+	if (high_score_file)
+	{
+		fscanf(high_score_file, "%d", &high_score); //파일에서 최고 기록 읽어오기
+		fclose(high_score_file); //파일 닫기
+	}	
+}
+
+void save_high_score(int score)
+{
+	FILE *high_score_file = fopen("high_score.txt", "w"); //high_score.txt 파일을 쓰기 모드로 열기
+	if (high_score_file)
+	{
+		fprintf(high_score_file, "%d", score); //파일에 최고 기록 쓰기
+		fclose(high_score_file); //파일 닫기
+	}
+}
+
 int main(int argc, char **argv)
 {
 	const char *exit_msg = "";
@@ -328,8 +350,9 @@ int main(int argc, char **argv)
 	int last_turn = game.turns;
 	time_t seed = time(NULL);
 	int opt;
-
 	int game_mode = 0;
+
+	load_high_score(); //게임 시작 시 최고 기록 불러오기
 
 	while ((opt = getopt(argc, argv, "hr:p:s:d:m:")) != -1) {
 		switch (opt) {
@@ -400,6 +423,17 @@ int main(int argc, char **argv)
 				place_tile(&game, Number);
 			}
 			record(key, &game);
+
+			if (game.score > high_score) //최고 기록을 갱신했다면?
+			{
+				high_score = game.score; //최고 기록 갱신
+				save_high_score(high_score); //해당 기록 파일에 저장
+				if (!batch_mode)
+				{
+					move(8,0);
+					printw("New high score: %d\n", high_score); //새로운 최고 기록 유저에게 알려주기
+				}
+			}
 		}
 	}
 
@@ -421,6 +455,14 @@ end:
 		"with largest tile %d\n",
 		exit_msg, game.score, game.turns,
 		1 << max_tile((tile *)game.board));
+
+	if (game.score > high_score) //게임 종료 시 최고 기록을 갱신했다면?
+	{
+		printf("Congratulations! New high score: %d\n", game.score); //게임 종료 시 새로운 최고 기록 알림
+	} else {
+		printf("High score: %d\n", high_score); //최고 기록 출력
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
high_score 라는 최고 기록을 저장하는 전역 변수를 생성해 최고 기록을 기록하도록 했습니다.
load_high_score() 함수를 만들어 게임을 시작하면 기존에 저장되어 있던 최고 기록을 불러오고 save_high_score() 함수를 통해 최고 기록이 갱신되면 해당 기록을 최고 기록으로 저장합니다.
게임 도중 최고 기록을 갱신하게 되면 그때부터 최고 기록이 현재 기록으로 누적되고 있는 것을 보여주며 게임이 끝났을 때 해당 기록을 다시 한 번 문구를 통해 보여줍니다.

점수 증가하는 부분이 잘 안 맞는 것 같아 수정했습니다..!
타일값이 이미 증가한 후에 계산을 하게 되어서 점수 증가가 2배로 되는 현상이 있어서 수정했습니다. 1커밋 1기능 수정/추가인 것을 알고있지만 제 컴퓨터에서는 수정하지 않으면 추가한 기능이 작동되지 않아 부득이하게 2개를 하나의 pr로 날립니다.