### PR TITLE
Fix: 점수 기록 기능 개선

### DIFF
--- a/2048_game.c
+++ b/2048_game.c
@@ -64,7 +64,10 @@ const char* get_mode_string(int mode) {
         case 1: return "Normal";
         case 2: return "Bomb";
         case 3: return "Chance";
-        default: return "Normal";
+        case 4: return "TimeAttack";
+	case 5: return "To 2000 score";
+	case 6: return "In 100, To 1000";
+	default: return "Normal";
     }
 }
 
@@ -791,14 +794,6 @@ int main(int argc, char **argv)
 	}
 
 	lose:
-		 // 게임이 종료되면 해당 게임의 정보를 구성합니다.
-                current_game_info.score = game.score;
-                current_game_info.turns = game.turns;
-                current_game_info.elapsed_time = elapsed_time;
-                current_game_info.mode = game_mode;
-                // 해당 게임의 정보를 파일에 기록합니다.
-                record_game_info(current_game_info);
-
 		if (batch_mode)
 		{
 			return 0;
@@ -808,6 +803,14 @@ int main(int argc, char **argv)
 		printw("You lose! Press q to quit.");
 		while (getch() != 'q');
 	end:
+  		// 게임이 종료되면 해당 게임의 정보를 구성합니다.
+                current_game_info.score = game.score;
+                current_game_info.turns = game.turns;
+                current_game_info.elapsed_time = elapsed_time;
+                current_game_info.mode = game_mode;
+                // 해당 게임의 정보를 파일에 기록합니다.
+                record_game_info(current_game_info);
+
 		if (batch_mode)
 		{
 			return 0;


### PR DESCRIPTION
게임모드가 3개 더 들어와서, 점수 기록할 때 새 모드 또한 모드 기록이 제대로 되도록 코드 수정하였습니다.
mode 4 -> TimeAttack
mode 5 -> To 2000 score
mode 6 -> In 100, To 1000

또한 게임 기록 저장을 main 의 lose: 에 구현하였는데, 게임에서 졌을 때 점수 기록이 아닌 게임이 끝났을 때 점수 기록하는 것이 더 맞는 거 같아서 게임 기록 저장 코드들을 end: 로 이동시켰습니다.